### PR TITLE
using rest_framework settings for default permission and authentications

### DIFF
--- a/backend/cfehome/settings.py
+++ b/backend/cfehome/settings.py
@@ -130,3 +130,13 @@ STATIC_URL = "static/"
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework.authentication.SessionAuthentication",
+        "api.authentication.TokenAuthentication",
+    ],
+    "DEFAULT_PERMISSION_CLASSES": [
+        "rest_framework.permissions.IsAuthenticatedOrReadOnly",
+    ],
+}

--- a/backend/products/views.py
+++ b/backend/products/views.py
@@ -15,6 +15,7 @@ from rest_framework.response import Response
 class ProductDetailApiView(generics.RetrieveAPIView):
     queryset = Product.objects.all()
     serializer_class = ProductSerializer
+    permission_classes = [permissions.IsAdminUser, IsStaffEditorPermission]
 
 
 product_detail_api_view = ProductDetailApiView.as_view()
@@ -23,8 +24,7 @@ product_detail_api_view = ProductDetailApiView.as_view()
 class ProductUpdateApiView(generics.UpdateAPIView):
     queryset = Product.objects.all()
     serializer_class = ProductSerializer
-    authentication_classes = [authentication.SessionAuthentication]
-    permission_classes = [permissions.DjangoModelPermissions]
+    permission_classes = [permissions.IsAdminUser, IsStaffEditorPermission]
     lookup_field = "pk"
 
     def perform_update(self, serializer):
@@ -37,6 +37,7 @@ class ProductUpdateApiView(generics.UpdateAPIView):
 class ProductDeleteApiView(generics.DestroyAPIView):
     queryset = Product.objects.all()
     serializer_class = ProductSerializer
+    permission_classes = [permissions.IsAdminUser, IsStaffEditorPermission]
     lookup_field = "pk"
 
     def perform_destroy(self, instance):
@@ -47,10 +48,6 @@ class ProductDeleteApiView(generics.DestroyAPIView):
 class ProductListCreateApiView(generics.ListCreateAPIView):
     queryset = Product.objects.all()
     serializer_class = ProductSerializer
-    authentication_classes = [
-        TokenAuthentication,
-        authentication.SessionAuthentication,
-    ]
     permission_classes = [permissions.IsAdminUser, IsStaffEditorPermission]
 
     def get(self, request, *args, **kwargs):


### PR DESCRIPTION
This section was basically using rest_framework settings to configure default authentication classes and permission classes. this is done using the django settings