### PR TITLE
using update and create method on serializers to add new custom fields

### DIFF
--- a/backend/products/serializers.py
+++ b/backend/products/serializers.py
@@ -8,6 +8,7 @@ all_fields = [
     "url",
     "item_url",
     "edit_url",
+    "email",
     "title",
     "content",
     "price",
@@ -22,6 +23,7 @@ class ProductSerializer(serializers.ModelSerializer):
     edit_url = serializers.HyperlinkedIdentityField(
         view_name="api:products:update", lookup_field="pk"
     )
+    email = serializers.EmailField(write_only=True)
 
     class Meta:
         model = Product
@@ -46,3 +48,15 @@ class ProductSerializer(serializers.ModelSerializer):
         if not isinstance(obj, Product):
             return None
         return obj.get_discount()
+
+    def create(self, validated_data):
+        # email = validated_data.pop("email", None)
+        instance = super().create(validated_data)
+        # print(instance)
+        return instance
+    
+    def update(self, instance, validated_data):
+        email = validated_data.pop("email", None)
+        print(f"This is the email = {email}")
+        instance = super().update(instance, validated_data)
+        return instance

--- a/backend/products/views.py
+++ b/backend/products/views.py
@@ -54,7 +54,9 @@ class ProductListCreateApiView(
     def perform_create(self, serializer):
         # serializer.save(user=self.request.user)
         title = serializer.validated_data.get("title")
+        email = serializer.validated_data.pop("email", None)
         content = serializer.validated_data.get("content", None)
+        print(f"this is the email = {email}")
         if not content:
             content = title
         serializer.save(content=content)


### PR DESCRIPTION
This PR focuses on using create and update method in serializers to add additional write_only fields to the serializers. in this special cases the fields are not usually on the instance of the model.